### PR TITLE
provide parse-exp out

### DIFF
--- a/utilities.rkt
+++ b/utilities.rkt
@@ -12,6 +12,7 @@
 
 #lang racket
 (require racket/struct)
+(provide parse-exp)
 
 ;; Version 0.2
 ;; ---------------------


### PR DESCRIPTION
parse-exp is provided by utilities.rkt now. This lets people use the support function from other racket programs or from interactive mode with a call to (require "utilities.rkt")

I'd be happy to update the changelog and whatever else. I think people would really benefit from being able to use this function to make tests.