### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.o
 *.s
 *.out
+*.out.dSYM
 *~
 
 # Compiled racket bytecode


### PR DESCRIPTION
Add `.out.dSYM` files with debug symbols, which are produced on Mac. See https://en.wikipedia.org/wiki/Debug_symbol#Apple

As usual, please feel free to close this PR.