### PR TITLE
Correct code after rename R* -> L*

### DIFF
--- a/compiler.rkt
+++ b/compiler.rkt
@@ -1,13 +1,13 @@
 #lang racket
 (require racket/set racket/stream)
 (require racket/fixnum)
-(require "interp-Rint.rkt")
-(require "interp-Rvar.rkt")
+(require "interp-Lint.rkt")
+(require "interp-Lvar.rkt")
 (require "utilities.rkt")
 (provide (all-defined-out))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Rint examples
+;; Lint examples
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; The following compiler pass is just a silly one that doesn't change
@@ -20,7 +20,7 @@
     [(Prim '- (list e1)) (Prim '- (list (flip-exp e1)))]
     [(Prim '+ (list e1 e2)) (Prim '+ (list (flip-exp e2) (flip-exp e1)))]))
 
-(define (flip-Rint e)
+(define (flip-Lint e)
   (match e
     [(Program info e) (Program info (flip-exp e))]))
 
@@ -43,7 +43,7 @@
     [(Prim '- (list e1)) (pe-neg (pe-exp e1))]
     [(Prim '+ (list e1 e2)) (pe-add (pe-exp e1) (pe-exp e2))]))
 
-(define (pe-Rint p)
+(define (pe-Lint p)
   (match p
     [(Program info e) (Program info (pe-exp e))]))
 
@@ -95,9 +95,9 @@
 ;; Note that your compiler file (the file that defines the passes)
 ;; must be named "compiler.rkt"
 (define compiler-passes
-  `( ("uniquify" ,uniquify ,interp-Rvar)
+  `( ("uniquify" ,uniquify ,interp-Lvar)
      ;; Uncomment the following passes as you finish them.
-     ;; ("remove complex opera*" ,remove-complex-opera* ,interp-Rvar)
+     ;; ("remove complex opera*" ,remove-complex-opera* ,interp-Lvar)
      ;; ("explicate control" ,explicate-control ,interp-Cvar)
      ;; ("instruction selection" ,select-instructions ,interp-x86-0)
      ;; ("assign homes" ,assign-homes ,interp-x86-0)

--- a/interp-Lcast.rkt
+++ b/interp-Lcast.rkt
@@ -2,9 +2,9 @@
 ;(require racket/fixnum)
 (require "utilities.rkt")
 (require "interp-Lwhile.rkt")
-(provide interp-Rcast interp-Rcast-class)
+(provide interp-Lcast interp-Lcast-class)
 
-(define interp-Rcast-class
+(define interp-Lcast-class
   (class interp-Lwhile-class
     (super-new)
     (inherit apply-fun apply-inject apply-project)
@@ -32,7 +32,7 @@
         [else (vector-length vec)]))
 
     (define/override (interp-op op)
-      (verbose "Rcast/interp-op" op)
+      (verbose "Lcast/interp-op" op)
       (match op
         ['vector-length guarded-vector-length]
         ['vector-ref guarded-vector-ref]
@@ -94,18 +94,18 @@
     
     (define/override ((interp-exp env) e)
       (define (recur e) ((interp-exp env) e))
-      (verbose "Rcast/interp-exp" e)
+      (verbose "Lcast/interp-exp" e)
       (define result
         (match e
           [(Value v) v]
           [(Cast e src tgt)
            (apply-cast (recur e) src tgt)]
           [else ((super interp-exp env) e)]))
-      (verbose "Rcast/interp-exp" e result)
+      (verbose "Lcast/interp-exp" e result)
       result)
     
     ))
 
-(define (interp-Rcast p)
-  (send (new interp-Rcast-class) interp-program p))
+(define (interp-Lcast p)
+  (send (new interp-Lcast-class) interp-program p))
 

--- a/interp-Lint.rkt
+++ b/interp-Lint.rkt
@@ -35,7 +35,7 @@
 
 
 ;; This version of the interpreter for Lint is the base class
-;; for interp-Rvar-class in interp-Rvar.rkt.
+;; for interp-Lvar-class in interp-Lvar.rkt.
 
 (define interp-Lint-class
   (class object%

--- a/interp.rkt
+++ b/interp.rkt
@@ -16,7 +16,7 @@
 ;; 
 ;; The interpreters for the source languages (Lvar, Lif, ...)
 ;; and the C intermediate languages Cvar and Cif
-;; are in separate files, e.g., interp-Rvar.rkt.
+;; are in separate files, e.g., interp-Lvar.rkt.
 
 #;(define interp-R3-prime
   (lambda (p)

--- a/run-tests.rkt
+++ b/run-tests.rkt
@@ -2,7 +2,7 @@
 #lang racket
 
 (require "utilities.rkt")
-(require "interp-Rvar.rkt")
+(require "interp-Lvar.rkt")
 (require "interp-Cvar.rkt")
 (require "interp.rkt")
 (require "compiler.rkt")
@@ -24,7 +24,7 @@
           (string=? r (car (string-split p "_"))))
         all-tests)))
 
-(interp-tests "var" #f compiler-passes interp-Rvar "var_test" (tests-for "var"))
+(interp-tests "var" #f compiler-passes interp-Lvar "var_test" (tests-for "var"))
 
 ;; Uncomment the following when all the passes are complete to
 ;; test the final x86 code.

--- a/utilities.rkt
+++ b/utilities.rkt
@@ -1816,6 +1816,10 @@ Changelog:
          (format "\t~a\t~a\n" instr-name (print-x86-imm d))]
         [(Retq)
          "\tretq\n"]
+        [(Pushq s)
+         (format "\tpushq\t~a\n" (print-x86-imm s))]
+        [(Popq d)
+         (format "\tpopq\t~a\n" (print-x86-imm d))]
         [(JmpIf cc label) (format "\tj~a ~a\n" cc (label-name label))]
         [else (error "print-x86-instr, unmatched" e)]))
     


### PR DESCRIPTION
Couple changes in `run-tests.rkt` and `Lcast` interpreter.

Please feel free to close, as usual.