### PR TITLE
fix type-check-Lfun for `Apply` type-check

### DIFF
--- a/type-check-Lfun.rkt
+++ b/type-check-Lfun.rkt
@@ -37,9 +37,9 @@
                                 ((type-check-exp env) e)))
       (match ty
         [`(,ty^* ... -> ,rt)
-         (for ([arg-ty ty*] [param-ty ty^*])
-           (check-type-equal? arg-ty param-ty (Apply e es)))
-         (values e^ e* rt)]
+		  (let ([expr (Apply e es)])
+			(for-each (lambda (at pt) (check-type-equal? at pt expr)) ty* ty^*))
+		  (values e^ e* rt)]
         [else (error 'type-check "expected a function, not ~a" ty)]))
 
     (define/override (type-check-exp env)


### PR DESCRIPTION
Quote from Racket document:
> The [for](https://docs.racket-lang.org/reference/for.html#%28form._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._for%29%29) form iterates by drawing an element from each sequence; if any sequence is empty, then the iteration stops

so if apply function with less or more arguments would still pass type-check in original code, the for-each checks length.